### PR TITLE
add deploy docker step in workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,3 +101,34 @@ jobs:
           files: ./reports/coverage.xml
           fail_ci_if_error: true
           verbose: true
+
+  deploy-docker:
+    needs: tests
+    if: ${{ success() && (contains(github.ref, 'refs/tags') || github.ref == 'refs/heads/master') }}
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_REPO: "pavics/cowbird"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+      - name: Get Tag Version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == "refs/heads/master" ]]; then
+            echo "::set-output name=TAG_VERSION::latest"
+          else
+            echo "::set-output name=TAG_VERSION::${GITHUB_REF##*/}"
+          fi
+      - name: Build Docker
+        run: |
+          make DOCKER_REPO=${DOCKER_REPO} APP_VERSION=${{ steps.version.outputs.TAG_VERSION }} docker-info docker-build
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Push to DockerHub
+        run: |
+          make DOCKER_REPO=${DOCKER_REPO} APP_VERSION=${{ steps.version.outputs.TAG_VERSION }} docker-push


### PR DESCRIPTION
I'm not certain why, but when I go to https://hub.docker.com/repository/docker/pavics/cowbird/builds/edit
The Ouranosinc/cowbird entry doesn't appear, although all others are visible... 

So instead, use the github workflow to deploy it manually upon master(latest) / tag updates. 
Step copy-pasted from Weaver's workflow with tweak of the target docker hub repo.

@tlvu 
Might need to set `DOCKER_USERNAME` and `DOCKERHUB_TOKEN` as secret variables in the repo settings, I cannot have access to those for this repo. I'm not sure if matching Ouranosinc org will be enough to push directly to docker hub or not.