### PR TITLE
add explicit DockerHub build hook to build both worker/webservice images

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,18 +135,18 @@ Following most recent variants are available:
 
 
 .. |cowbird_tag_base| replace:: pavics/cowbird:0.4.0
-.. _cowbird_tag_base: https://hub.docker.com/r/pavics/magpie/tags?page=1&ordering=last_updated&name=0.4.0
+.. _cowbird_tag_base: https://hub.docker.com/r/pavics/cowbird/tags?page=1&ordering=last_updated&name=0.4.0
 .. |cowbird_tag_worker| replace:: pavics/cowbird:0.4.0-worker
-.. _cowbird_tag_worker: https://hub.docker.com/r/pavics/magpie/tags?page=1&ordering=last_updated&name=0.4.0-worker
+.. _cowbird_tag_worker: https://hub.docker.com/r/pavics/cowbird/tags?page=1&ordering=last_updated&name=0.4.0-worker
 .. |cowbird_tag_websvc| replace:: pavics/cowbird:0.4.0-webservice
-.. _cowbird_tag_websvc: https://hub.docker.com/r/pavics/magpie/tags?page=1&ordering=last_updated&name=0.4.0-webservice
+.. _cowbird_tag_websvc: https://hub.docker.com/r/pavics/cowbird/tags?page=1&ordering=last_updated&name=0.4.0-webservice
 
 .. |cowbird_latest_base| replace:: pavics/cowbird:latest
-.. _cowbird_latest_base: https://hub.docker.com/r/pavics/magpie/tags?page=1&ordering=last_updated&name=latest
+.. _cowbird_latest_base: https://hub.docker.com/r/pavics/cowbird/tags?page=1&ordering=last_updated&name=latest
 .. |cowbird_latest_worker| replace:: pavics/cowbird:latest-worker
-.. _cowbird_latest_worker: https://hub.docker.com/r/pavics/magpie/tags?page=1&ordering=last_updated&name=latest-worker
+.. _cowbird_latest_worker: https://hub.docker.com/r/pavics/cowbird/tags?page=1&ordering=last_updated&name=latest-worker
 .. |cowbird_latest_websvc| replace:: pavics/cowbird:latest-webservice
-.. _cowbird_latest_websvc: https://hub.docker.com/r/pavics/magpie/tags?page=1&ordering=last_updated&name=latest-webservice
+.. _cowbird_latest_websvc: https://hub.docker.com/r/pavics/cowbird/tags?page=1&ordering=last_updated&name=latest-webservice
 
 
 **Notes:**

--- a/README.rst
+++ b/README.rst
@@ -118,10 +118,35 @@ Following most recent variants are available:
 
 .. list-table::
     :header-rows: 1
+    :stub-columns: 1
 
-    * - Cowbird
-    * - pavics/cowbird:0.4.0
-    * - pavics/cowbird:latest
+    * - Version
+      - Cowbird Base
+      - Cowbird Worker
+      - Cowbird Web Service
+    * - Most Recent Release
+      - |cowbird_tag_base|_
+      - |cowbird_tag_worker|_
+      - |cowbird_tag_websvc|_
+    * - Latest Commit
+      - |cowbird_latest_base|_
+      - |cowbird_latest_worker|_
+      - |cowbird_latest_websvc|_
+
+
+.. |cowbird_tag_base| replace:: pavics/cowbird:0.4.0
+.. _cowbird_tag_base: https://hub.docker.com/r/pavics/magpie/tags?page=1&ordering=last_updated&name=0.4.0
+.. |cowbird_tag_worker| replace:: pavics/cowbird:0.4.0-worker
+.. _cowbird_tag_worker: https://hub.docker.com/r/pavics/magpie/tags?page=1&ordering=last_updated&name=0.4.0-worker
+.. |cowbird_tag_websvc| replace:: pavics/cowbird:0.4.0-webservice
+.. _cowbird_tag_websvc: https://hub.docker.com/r/pavics/magpie/tags?page=1&ordering=last_updated&name=0.4.0-webservice
+
+.. |cowbird_latest_base| replace:: pavics/cowbird:latest
+.. _cowbird_latest_base: https://hub.docker.com/r/pavics/magpie/tags?page=1&ordering=last_updated&name=latest
+.. |cowbird_latest_worker| replace:: pavics/cowbird:latest-worker
+.. _cowbird_latest_worker: https://hub.docker.com/r/pavics/magpie/tags?page=1&ordering=last_updated&name=latest-worker
+.. |cowbird_latest_websvc| replace:: pavics/cowbird:latest-webservice
+.. _cowbird_latest_websvc: https://hub.docker.com/r/pavics/magpie/tags?page=1&ordering=last_updated&name=latest-webservice
 
 
 **Notes:**

--- a/hooks/.gitignore
+++ b/hooks/.gitignore
@@ -1,0 +1,4 @@
+*.*
+!.gitignore
+!build
+!README.md

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,2 @@
+Files placed in this directory are for additional/override DockerHub auto-build hook procedures.
+see: https://docs.docker.com/docker-hub/builds/advanced/

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "=> Information of Cowbird images to build (docker tag: $DOCKER_TAG)"
+make APP_VERSION=${DOCKER_TAG} docker-info
+
+echo "=> Building variations of Cowbird images (docker tag: $DOCKER_TAG)"
+make APP_VERSION=${DOCKER_TAG} docker-build


### PR DESCRIPTION
## Summary

Resolve the failing builds on DockerHub since `Dockerfile` was moved under `docker/` and separated into 3 distinct builds for `-base`, `-worker` and `-webservice` variants. 

Failing builds: 
- https://hub.docker.com/repository/registry-1.docker.io/pavics/cowbird/builds/2a59ccdc-850a-4653-b613-3165187c4678
- https://hub.docker.com/repository/registry-1.docker.io/pavics/cowbird/builds/ca20a512-89d5-4c2f-9949-124555d8283d
- etc.

Failing tag releases (`0.3.0` and `0.4.0`) have been pushed manually after local build in the meantime.

## Changes

- Add the build hook script using makefile to build all variations of cowbird image on merge/tag trigger
- Add references to built images in readme
