### PR TITLE
fix breaking documentation due to package incompatibilities

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,6 +1,8 @@
 # these are doc-only requirements
-# we actually need to install all requirements during docs build because of OpenAPI generation
-# (see 'docs/conf.py')
+# we actually need to install all requirements during docs build because of OpenAPI generation (see 'docs/conf.py')
+
+# sphinx-autoapi breaking with astroid==2.7 (https://github.com/readthedocs/sphinx-autoapi/issues/301)
+astroid>=2.6,!=2.7,<3
 pycodestyle
 sphinx-autoapi>=1.7.0
 sphinx-paramlinks>=0.4.1


### PR DESCRIPTION
## Changes

* Fix breaking `astroid==2.7` with `sphinx-autoapi` (relates to https://github.com/readthedocs/sphinx-autoapi/issues/301)

## References

Failing documentation build due to related issue: https://readthedocs.org/projects/pavics-cowbird/builds/14485165/