### PR TITLE
improve error reporting on `/version` endpoint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@ Features / Changes
 * Return `HTTP 424 (Failed Dependency)` when the `celery` worker version cannot be retrieved on ``GET /version``.
   Also, provide better error logs and detail messages in case of error to help debug the cause of the problem.
 
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* Fix incorrect typings and typographic errors.
+
 `1.1.0 <https://github.com/Ouranosinc/cowbird/tree/1.1.0>`_ (2023-03-14)
 ------------------------------------------------------------------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,10 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/cowbird/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing yet.
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+* Return `HTTP 424 (Failed Dependency)` when the `celery` worker version cannot be retrieved on ``GET /version``.
+  Also, provide better error logs and detail messages in case of error to help debug the cause of the problem.
 
 `1.1.0 <https://github.com/Ouranosinc/cowbird/tree/1.1.0>`_ (2023-03-14)
 ------------------------------------------------------------------------------------

--- a/config/celeryconfig.py
+++ b/config/celeryconfig.py
@@ -1,7 +1,7 @@
-broker_url = "mongodb://0.0.0.0:27017/jobs"
+broker_url = "mongodb://0.0.0.0:27017/cowbird-jobs"
 result_backend = "mongodb://0.0.0.0:27017"
 mongodb_backend_settings = {
-    "database": "jobs-result",
+    "database": "cowbird-jobs",
     "taskmeta_collection": "celery_tasks",
 }
 result_persistent = False

--- a/cowbird/api/home/views.py
+++ b/cowbird/api/home/views.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 
 import celery.exceptions
 from celery import shared_task
-from pyramid.httpexceptions import HTTPOk, HTTPFailedDependency, HTTPInternalServerError
+from pyramid.httpexceptions import HTTPFailedDependency, HTTPInternalServerError, HTTPOk
 from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.view import view_config
 

--- a/cowbird/api/schemas.py
+++ b/cowbird/api/schemas.py
@@ -7,6 +7,7 @@ from cornice_swagger.swagger import CorniceSwagger
 from pyramid.httpexceptions import (
     HTTPBadRequest,
     HTTPConflict,
+    HTTPFailedDependency,
     HTTPForbidden,
     HTTPInternalServerError,
     HTTPMethodNotAllowed,
@@ -676,6 +677,11 @@ class Version_GET_OkResponseSchema(BaseResponseSchemaAPI):
     body = Version_GET_ResponseBodySchema(code=HTTPOk.code, description=description)
 
 
+class FailedDependencyErrorResponseSchema(BaseResponseSchemaAPI):
+    description = "Version dependencies could not all be identified."
+    body = ErrorResponseBodySchema(code=HTTPFailedDependency.code, description=description)
+
+
 class Homepage_GET_OkResponseSchema(BaseResponseSchemaAPI):
     description = "Get homepage successful."
     body = BaseResponseBodySchema(code=HTTPOk.code, description=description)
@@ -736,6 +742,7 @@ PermissionWebhook_POST_responses = {
 Version_GET_responses = {
     "200": Version_GET_OkResponseSchema(),
     "406": NotAcceptableResponseSchema(),
+    "424": FailedDependencyErrorResponseSchema(),
     "500": InternalServerErrorResponseSchema(),
 }
 Homepage_GET_responses = {

--- a/cowbird/app.py
+++ b/cowbird/app.py
@@ -43,7 +43,7 @@ def get_app(global_config=None, **settings):
         for sync_cfg in sync_perm_config.values():
             validate_sync_config(sync_cfg)
     if not sync_perm_cfgs:
-        LOGGER.warning("No permssion mapping configuration found in [%s]", config_path)
+        LOGGER.warning("No permission mapping configuration found in [%s]", config_path)
 
     print_log("Starting Cowbird app...", LOGGER)
     wsgi_app = config.make_wsgi_app()

--- a/cowbird/handlers/impl/catalog.py
+++ b/cowbird/handlers/impl/catalog.py
@@ -32,7 +32,7 @@ class Catalog(Handler, FSMonitor):
         # TODO: Need to monitor data directory
 
     def get_resource_id(self, resource_full_name):
-        # type (str) -> str
+        # type: (str) -> str
         raise NotImplementedError
 
     def user_created(self, user_name):

--- a/cowbird/handlers/impl/filesystem.py
+++ b/cowbird/handlers/impl/filesystem.py
@@ -36,7 +36,7 @@ class FileSystem(Handler):
         self.jupyterhub_user_data_dir = jupyterhub_user_data_dir
 
     def get_resource_id(self, resource_full_name):
-        # type (str) -> str
+        # type: (str) -> str
         raise NotImplementedError
 
     def _get_user_workspace_dir(self, user_name):

--- a/cowbird/handlers/impl/magpie.py
+++ b/cowbird/handlers/impl/magpie.py
@@ -84,7 +84,7 @@ class Magpie(Handler):
         return self.service_types
 
     def get_resource_id(self, resource_full_name):
-        # type (str) -> str
+        # type: (str) -> str
         raise NotImplementedError
 
     def get_resources_tree(self, resource_id):

--- a/cowbird/handlers/impl/nginx.py
+++ b/cowbird/handlers/impl/nginx.py
@@ -26,7 +26,7 @@ class Nginx(Handler):
         super(Nginx, self).__init__(settings, name, **kwargs)
 
     def get_resource_id(self, resource_full_name):
-        # type (str) -> str
+        # type: (str) -> str
         raise NotImplementedError
 
     def user_created(self, user_name):

--- a/cowbird/handlers/impl/thredds.py
+++ b/cowbird/handlers/impl/thredds.py
@@ -26,7 +26,7 @@ class Thredds(Handler):
         super(Thredds, self).__init__(settings, name, **kwargs)
 
     def get_resource_id(self, resource_full_name):
-        # type (str) -> str
+        # type: (str) -> str
         raise NotImplementedError
 
     def user_created(self, user_name):

--- a/cowbird/utils.py
+++ b/cowbird/utils.py
@@ -177,7 +177,7 @@ def configure_celery(config, config_ini):
 
     # shared_tasks use the default celery app by default so setting the pyramid_celery celery_app as default prevent
     # celery to create its own app instance (which is not configured properly and is bugging the shared tasks).
-    # Also it must be done early because as soon as config scan is started, some packages may include celery and
+    # Also, it must be done early because as soon as config scan is started, some packages may include celery,
     # and it will create its own app instance.
     #
     # ** If the test celery app must be used, nothing has to be done since this is already the default app **
@@ -208,7 +208,7 @@ def configure_celery(config, config_ini):
 
 
 def get_app_config(container):
-    # type: (AnySettingsContainer, bool) -> Configurator
+    # type: (AnySettingsContainer) -> Configurator
     """
     Generates application configuration with all required utilities and settings configured.
     """

--- a/tests/test_request_task.py
+++ b/tests/test_request_task.py
@@ -45,7 +45,7 @@ class UnreliableRequestTask(RequestTask, ABC):
 
 @shared_task(bind=True, base=UnreliableRequestTask)
 def unreliable_request_task(self, param1, param2):
-    # type (int, int) -> int
+    # type: (RequestTask, int, int) -> int
     if self.request.retries < UnreliableRequestTask.test_max_retries:
         raise RequestException()
     return param1 + param2
@@ -53,14 +53,14 @@ def unreliable_request_task(self, param1, param2):
 
 @shared_task(bind=True, base=RequestTask)
 def abort_sum_task(self, param1, param2):
-    # type (int, int) -> int
+    # type: (RequestTask, int, int) -> int
     self.abort_chain()
     return param1 + param2
 
 
 @shared_task(base=RequestTask)
 def sum_task(param1, param2):
-    # type (int, int) -> int
+    # type: (int, int) -> int
     return param1 + param2
 
 


### PR DESCRIPTION
# Features / Changes

* Return `HTTP 424 (Failed Dependency)` when the `celery` worker version cannot be retrieved on ``GET /version``.
  Also, provide better error logs and detail messages in case of error to help debug the cause of the problem.

# Bug Fixes
* Fix incorrect typings and typographic errors.

Relates to #33 

