### PR TITLE
Permission update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,14 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/cowbird/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing yet.
+* Add optional key ``field`` and ``regex`` to be used in the ``sync_permissions`` section found in the config.
+  This allow to sync permission using a field other than ``resource_full_name`` when creating the nametype path
+  from the segment ``ex.: /field1::type1/field2::type2``. This adds the support of using ``resource_display_name``.
+* The ``regex`` is used to extract the desired information from the ``nametype_path`` that should be used to do an
+  exact match. This new search overrides the default way of matching each segment with the ``nametype path``. 
+  In the case where a ``regex`` is found in the target segment, the data will be formed using the same ``resource_type``
+  for every match in the same segment. Similary, as using ``- name: "**"`` in the config to match multiple segment,
+  it is possible to use a ``regex`` to match multiple directory in the same segment with ``regex: '(?<=:).*\/?(?=\/)' ``
 
 `2.1.0 <https://github.com/Ouranosinc/cowbird/tree/2.1.0>`_ (2023-09-18)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,13 +8,13 @@ Changes
 ------------------------------------------------------------------------------------
 
 * Add optional key ``field`` and ``regex`` to be used in the ``sync_permissions`` section found in the config.
-  This allow to sync permission using a field other than ``resource_full_name`` when creating the nametype path
-  from the segment ``ex.: /field1::type1/field2::type2``. This adds the support of using ``resource_display_name``.
+  This allows to sync permissions using a field other than ``resource_full_name`` when creating the ``name:type``
+  from the segment ``ex.: /field1::type1/field2::type2``. Adds support to use ``resource_display_name``.
 * The ``regex`` is used to extract the desired information from the ``nametype_path``. It should be used to do an
-  exact match. This new search overrides the default way of matching each segment with the ``nametype path``. 
+  exact match. This new search overrides the default way of matching each segment with the ``nametype_path``. 
   In the case where a ``regex`` is found in the target segment, the data will be formed using the same ``resource_type``
   for every match in the same segment. Similary, as using ``- name: "**"`` in the config to match multiple segment,
-  it is possible to use a ``regex`` to match multiple directory in the same segment with ``regex: '(?<=:).*\/?(?=\/)'``
+  it is possible to use a ``regex`` to match multiple resources in the same segment with ``regex: '(?<=:).*\/?(?=\/)'``
 
 `2.1.0 <https://github.com/Ouranosinc/cowbird/tree/2.1.0>`_ (2023-09-18)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Changes
   This allows to sync permissions using a field other than ``resource_full_name`` when creating the ``name:type``
   from the segment ``ex.: /field1::type1/field2::type2``. Adds support to use ``resource_display_name``.
 * The ``regex`` is used to extract the desired information from the ``nametype_path``. It should be used to do an
-  exact match. This new search overrides the default way of matching each segment with the ``nametype_path``. 
+  exact match. This new search overrides the default way of matching each segment with the ``nametype_path``.
   In the case where a ``regex`` is found in the target segment, the data will be formed using the same ``resource_type``
   for every match in the same segment. Similary, as using ``- name: "**"`` in the config to match multiple segment,
   it is possible to use a ``regex`` to match multiple resources in the same segment with ``regex: '(?<=:).*\/?(?=\/)'``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,11 +10,11 @@ Changes
 * Add optional key ``field`` and ``regex`` to be used in the ``sync_permissions`` section found in the config.
   This allow to sync permission using a field other than ``resource_full_name`` when creating the nametype path
   from the segment ``ex.: /field1::type1/field2::type2``. This adds the support of using ``resource_display_name``.
-* The ``regex`` is used to extract the desired information from the ``nametype_path`` that should be used to do an
+* The ``regex`` is used to extract the desired information from the ``nametype_path``. It should be used to do an
   exact match. This new search overrides the default way of matching each segment with the ``nametype path``. 
   In the case where a ``regex`` is found in the target segment, the data will be formed using the same ``resource_type``
   for every match in the same segment. Similary, as using ``- name: "**"`` in the config to match multiple segment,
-  it is possible to use a ``regex`` to match multiple directory in the same segment with ``regex: '(?<=:).*\/?(?=\/)' ``
+  it is possible to use a ``regex`` to match multiple directory in the same segment with ``regex: '(?<=:).*\/?(?=\/)'``
 
 `2.1.0 <https://github.com/Ouranosinc/cowbird/tree/2.1.0>`_ (2023-09-18)
 ------------------------------------------------------------------------------------

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -183,7 +183,7 @@ sync_permissions:
       - "process_job_status : read -> job_status : read"
       # different permission (match), otherwise all jobs/outputs become available.
       - "process_job_status : read -> process_description : read-match"
-stac_permissions:
+  stac_permissions:
     services:
       api:
         stac_collection:
@@ -216,8 +216,8 @@ stac_permissions:
           - name: thredds
             type: service            
           - type: directory
-            regex: '(?<=:)[\w\/]+' # Match everything after ":" but before last "/" (ex: thredds:birdhouse/testdata/xclim/cmip6 will match to : birdhouse/testdata/xclim/cmip6)
-                                   # It would be equivalent as matching any number of directory using "**"
+            regex: '(?<=:)[\w\/]+' # Match everything after ":" but before last "/" (ex: thredds:birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc
+                                   # will match to : birdhouse/testdata/xclim/cmip6). It would be equivalent as matching any number of directory using "**".
         thredd_item:
           - name: thredds
             type: service

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -216,7 +216,7 @@ sync_permissions:
           - name: thredds
             type: service            
           - type: directory
-            regex: '(?<=:)[\w\/]+' # Match everything after ":" but before last "/" (ex: thredds:birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc
+            regex: '(?<=:).*\/?(?=\/)' # Match everything after ":" but before last "/" (ex: thredds:birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc
                                    # will match to : birdhouse/testdata/xclim/cmip6). It would be equivalent as matching any number of directory using "**".
         thredd_item:
           - name: thredds

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -183,3 +183,58 @@ sync_permissions:
       - "process_job_status : read -> job_status : read"
       # different permission (match), otherwise all jobs/outputs become available.
       - "process_job_status : read -> process_description : read-match"
+stac_permissions:
+    services:
+      api:
+        stac_collection:
+          - name: stac
+            type: service
+          - name: stac
+            type: route
+          - name: collections
+            type: route
+          - type: route
+            field: resource_display_name # Use the resource_display_name for permission mapping.
+            regex: '[\w]+:[\w\/]+' # This will extract the display name (ex: thredds:birdhouse/testdata/xclim/cmip6).
+        stac_item:
+          - name: stac
+            type: service
+          - name: stac
+            type: route
+          - name: collections
+            type: route
+          - name: "{collectionId}"
+            type: route
+          - name: items
+            type: route
+          - type: route
+            field: resource_display_name # Use the resource_display_name for permission mapping.
+            regex: '[\w]+:[\w\/.-]+' # This will extract the display name (ex: thredds:birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc)
+
+      thredds: 
+        thredd_collection:
+          - name: thredds
+            type: service            
+          - type: directory
+            regex: '(?<=:)[\w\/]+' # Match everything after ":" but before last "/" (ex: thredds:birdhouse/testdata/xclim/cmip6 will match to : birdhouse/testdata/xclim/cmip6)
+                                   # It would be equivalent as matching any number of directory using "**"
+        thredd_item:
+          - name: thredds
+            type: service
+          - type: directory
+            regex: '(?<=:).*\/?(?=\/)' # Match everything after ":" but before last "/" example thredds:birdhouse/testdata/xclim/cmip6/sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc
+                                       # will return birdhouse/testdata/xclim/cmip6. This would create recreate the same hierarchy of directories. 
+          - type: file
+            regex: '[^\/]+$' # Match a file in a leaf directory (ex: sic_SImon_CCCma-CanESM5_ssp245_r13i1p2f1_2020.nc).
+
+    permissions_mapping:
+      # Permission mapping relating to the stac collection mapped to a thredd directory.
+      - "stac_collection : read-match -> thredd_collection : browse-match"
+      - "stac_collection : read-allow-recursive -> thredd_collection : browse-allow-recursive"
+      - "stac_collection : read-deny-match -> thredd_collection : browse-deny-match"
+      - "stac_collection : read-deny-recursive -> thredd_collection : browse-deny-recursive"
+      # Permission mapping relating to the stac item mapped to a thredd file.
+      - "stac_item : read-match -> thredd_item : browse-match"
+      - "stac_item : read-allow-recursive -> thredd_item : browse-allow-recursive"
+      - "stac_item : read-deny-match -> thredd_item : browse-deny-match"
+      - "stac_item : read-deny-recursive -> thredd_item : browse-deny-recursive"

--- a/cowbird/api/webhooks/views.py
+++ b/cowbird/api/webhooks/views.py
@@ -108,13 +108,13 @@ def post_permission_webhook_view(request: Request) -> AnyResponseType:
                     msg_on_fail=s.PermissionWebhook_POST_BadRequestResponseSchema.description)
     # Use raw value for service name, to avoid errors with `None` values
     # when the permission is not applied to a `service` type resource.
-    resource_display_name = ar.get_multiformat_body(request, "resource_display_name", check_type=(str, type(None)))
     service_name = ar.get_multiformat_body(request, "service_name", check_type=(str, type(None)))
     service_type = ar.get_multiformat_body(request, "service_type")
     resource_id = ar.get_multiformat_body(request, "resource_id", check_type=int)
     param_regex_with_slashes = r"^/?[A-Za-z0-9]+(?:[\s_\-\./:][A-Za-z0-9]+)*$"
     resource_full_name = ar.get_multiformat_body(request, "resource_full_name",
                                                  pattern=param_regex_with_slashes)
+    resource_display_name = ar.get_multiformat_body(request, "resource_display_name", check_type=(str, type(None)))
     name = ar.get_multiformat_body(request, "name")
     access = ar.get_multiformat_body(request, "access")
     scope = ar.get_multiformat_body(request, "scope")

--- a/cowbird/api/webhooks/views.py
+++ b/cowbird/api/webhooks/views.py
@@ -108,6 +108,7 @@ def post_permission_webhook_view(request: Request) -> AnyResponseType:
                     msg_on_fail=s.PermissionWebhook_POST_BadRequestResponseSchema.description)
     # Use raw value for service name, to avoid errors with `None` values
     # when the permission is not applied to a `service` type resource.
+    resource_display_name = ar.get_multiformat_body(request, "resource_display_name", check_type=(str, type(None)))
     service_name = ar.get_multiformat_body(request, "service_name", check_type=(str, type(None)))
     service_type = ar.get_multiformat_body(request, "service_type")
     resource_id = ar.get_multiformat_body(request, "resource_id", check_type=int)
@@ -127,6 +128,7 @@ def post_permission_webhook_view(request: Request) -> AnyResponseType:
         service_type=service_type,
         resource_id=resource_id,
         resource_full_name=resource_full_name,
+        resource_display_name=resource_display_name,
         name=name,
         access=access,
         scope=scope,

--- a/cowbird/config.py
+++ b/cowbird/config.py
@@ -191,7 +191,7 @@ def validate_sync_perm_config_schema(sync_cfg: SyncPointConfig) -> None:
             "services": {
                 str: {  # Service type, must correspond to an actual Magpie service type
                     str: [  # Resource key, used to identify the resource here and in the permissions_mapping
-                        {"name": str, "type": str, Optional('field'): str, Optional('regex'): str}
+                        {"name": str, "type": str, Optional("field"): str, Optional("regex"): str}
                     ]
                 }
             },

--- a/cowbird/config.py
+++ b/cowbird/config.py
@@ -191,7 +191,7 @@ def validate_sync_perm_config_schema(sync_cfg: SyncPointConfig) -> None:
             "services": {
                 str: {  # Service type, must correspond to an actual Magpie service type
                     str: [  # Resource key, used to identify the resource here and in the permissions_mapping
-                        {"name": str, "type": str}
+                        {"name": str, "type": str, Optional('field'): str, Optional('regex'): str}
                     ]
                 }
             },

--- a/cowbird/handlers/impl/magpie.py
+++ b/cowbird/handlers/impl/magpie.py
@@ -431,13 +431,14 @@ class Magpie(Handler):
         else:
             LOGGER.warning("Empty permission data, no permissions to remove.")
 
-    def create_resource(self, resource_name: str, resource_type: str, parent_id: Optional[int]) -> int:
+    def create_resource(self, resource_name: str, resource_type: str, parent_id: Optional[int],
+                        resource_display_name: Optional[str] = None) -> int:
         """
         Creates the specified resource in Magpie and returns the created resource id if successful.
         """
         resource_data = {
             "resource_name": resource_name,
-            "resource_display_name": resource_name,
+            "resource_display_name": resource_display_name,
             "resource_type": resource_type,
             "parent_id": parent_id
         }

--- a/cowbird/handlers/impl/magpie.py
+++ b/cowbird/handlers/impl/magpie.py
@@ -438,7 +438,7 @@ class Magpie(Handler):
         """
         resource_data = {
             "resource_name": resource_name,
-            "resource_display_name": resource_display_name,
+            "resource_display_name": resource_display_name or resource_name,
             "resource_type": resource_type,
             "parent_id": parent_id
         }

--- a/cowbird/permissions_synchronizer.py
+++ b/cowbird/permissions_synchronizer.py
@@ -1,6 +1,6 @@
 import re
 from copy import deepcopy
-from typing import TYPE_CHECKING, Callable, Dict, Iterator, List, MutableMapping, Tuple, Union, cast
+from typing import TYPE_CHECKING, Callable, Collection, Dict, Iterator, List, MutableMapping, Tuple, cast
 
 from cowbird.config import (
     BIDIRECTIONAL_ARROW,
@@ -237,7 +237,7 @@ class SyncPoint:
                 formatted_path += "/" + segment.split(RES_NAMETYPE_SEPARATOR)[0]
         return formatted_path
 
-    def _find_matching_res(self, permission: Permission, src_resource_tree: ResourceTree) -> Tuple[str, Dict[str, str] or str]:
+    def _find_matching_res(self, permission: Permission, src_resource_tree: ResourceTree) -> Tuple[str, Collection[str]]:
         """
         Finds a resource key that matches the input resource path, in the sync_permissions config. Note that it returns
         the longest match and only the named segments of the path are included in the length value. Any tokenized
@@ -307,7 +307,7 @@ class SyncPoint:
 
     @staticmethod
     def _create_res_data(target_segments: List[ConfigSegment],
-                         input_matched_groups: Dict[str, str],
+                         input_matched_groups: Collection[str],
                          ) -> List[ResourceSegment]:
         """
         Creates resource data, by replacing any tokens found in the segment names to their actual corresponding values.
@@ -357,7 +357,7 @@ class SyncPoint:
 
     def _get_resource_full_name_and_type(self,
                                          res_key: str,
-                                         matched_groups: Dict[str, str] or str,
+                                         matched_groups: Collection[str],
                                          ) -> Tuple[str, List[ResourceSegment]]:
         """
         Finds the resource data from the config by using the resource key.
@@ -417,7 +417,7 @@ class SyncPoint:
     def _filter_used_targets(self,
                              target_res_and_permissions: TargetResourcePermissions,
                              input_src_res_key: str,
-                             src_matched_groups: Dict[str, str],
+                             src_matched_groups: Collection[str],
                              input_permission: Permission,
                              ) -> Tuple[Dict[str, List[str]], Dict[str, List[str]]]:
         """
@@ -496,7 +496,7 @@ class SyncPoint:
     def _get_permission_data(self,
                              user_targets: Dict[str, List[str]],
                              group_targets: Dict[str, List[str]],
-                             src_matched_groups: Dict[str, str],
+                             src_matched_groups: Collection[str],
                              input_permission: Permission) -> PermissionData:
         """
         Formats permissions data to send to Magpie. Output contains, for each target resource key, the resource path
@@ -537,7 +537,7 @@ class SyncPoint:
                                        target_res_and_permissions: TargetResourcePermissions,
                                        input_permission: Permission,
                                        input_src_res_key: str,
-                                       src_matched_groups: Dict[str, str],
+                                       src_matched_groups: Collection[str],
                                        ) -> PermissionData:
         """
         Removes every source resource found in the mappings that has an existing permission that is synced to one of the
@@ -553,7 +553,7 @@ class SyncPoint:
 
     def _find_permissions_to_sync(self,
                                   src_res_key: str,
-                                  src_matched_groups: Dict[str, str] or str,
+                                  src_matched_groups: Collection[str],
                                   input_permission: Permission,
                                   perm_operation: Callable[[List[PermissionConfigItemType]], None],
                                   ) -> PermissionData:

--- a/cowbird/permissions_synchronizer.py
+++ b/cowbird/permissions_synchronizer.py
@@ -1,6 +1,6 @@
 import re
 from copy import deepcopy
-from typing import TYPE_CHECKING, Callable, Dict, Iterator, List, MutableMapping, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Callable, Dict, Iterator, List, MutableMapping, Tuple, Union, cast
 
 from cowbird.config import (
     BIDIRECTIONAL_ARROW,
@@ -187,18 +187,17 @@ class SyncPoint:
         for segment in res_segments:
             matched_groups = re.match(NAMED_TOKEN_REGEX, segment["name"])
             if matched_groups:
-                if segment.get('regex') is not None:
+                if segment.get("regex") is not None:
                     # if a regex is passed, override the current regex and return
-                    regex = segment.get('regex')
+                    regex = segment.get("regex")
                     res_regex = (
-                            rf"{regex}"
-                        )
+                        rf"{regex}"
+                    )
                     return res_regex, -1
-                else:
-                    # match any name with specific type 1 time only
-                    res_regex += (
-                        rf"/(?P<{matched_groups.groups()[0]}>{SEGMENT_NAME_REGEX})"
-                        rf"{RES_NAMETYPE_SEPARATOR}{segment['type']}"
+                # match any name with specific type 1 time only
+                res_regex += (
+                    rf"/(?P<{matched_groups.groups()[0]}>{SEGMENT_NAME_REGEX})"
+                    rf"{RES_NAMETYPE_SEPARATOR}{segment['type']}"
                 )
             elif segment["name"] == MULTI_TOKEN:
                 # match any name with specific type, 0 or more times
@@ -211,22 +210,21 @@ class SyncPoint:
         return res_regex, named_segments_count
 
     @staticmethod
-    def _generate_nametype_path_from_segments(res_segments: List[ConfigSegment], src_resource_tree: ResourceTree ) -> str:
+    def _generate_nametype_path_from_segments(res_segments: List[ConfigSegment], src_resource_tree: ResourceTree) -> str:
         """
         Generate nametype path (ex.: /name1::type1/name2::type2 where name can be a key from src_resource_tree ).
         """
         resource_nametype_path = ""
         index = 0
         for res in src_resource_tree:
-            if(index < len(res_segments)):
-                key = res_segments[index].get('field') if res_segments[index].get('field') is not None else "resource_name"
+            if index < len(res_segments):
+                key = res_segments[index].get("field") if res_segments[index].get("field") is not None else "resource_name"
             else:
-                key = 'resource_name'
-            resource_nametype_path += f"/{res[key]}{RES_NAMETYPE_SEPARATOR}{res['resource_type']}"
+                key = "resource_name"
+            resource_nametype_path += f'/{res[key]}{RES_NAMETYPE_SEPARATOR}{res["resource_type"]}'
             index = index + 1
 
         return resource_nametype_path
-
 
     @staticmethod
     def _remove_type_from_nametype_path(nametype_path: str) -> str:
@@ -249,7 +247,7 @@ class SyncPoint:
         :param resource_nametype_path: Full resource path name, which includes the type of each segment
                                        (ex.: /name1::type1/name2::type2)
         """
-        
+
         service_type = permission.service_type
         if service_type in self.services:
             # Find which resource from the config matches with the input permission's resource tree
@@ -277,7 +275,7 @@ class SyncPoint:
                 res_regex, named_segments_count = SyncPoint._generate_regex_from_segments(res_segments)
                 resource_nametype_path = SyncPoint._generate_nametype_path_from_segments(res_segments, src_resource_tree)
                 if named_segments_count == -1:
-                    # To be able to match a path anywhere in the resource_nametype_path we need to use search 
+                    # To be able to match a path anywhere in the resource_nametype_path we need to use search
                     # only when the field regex is passed in the res_segments. This allow to stay backward compatible.
                     matches = re.search(res_regex, resource_nametype_path)
                 else:
@@ -291,7 +289,7 @@ class SyncPoint:
                         )
                     matched_groups_by_res[res_key] = matched_groups
                     # Since we want to be able to match multiple dir /dir1/dir2/dir3/** in the same segment if a custom regex is passed.
-                    # We need to use the len of the exact match to avoid matching the wrong res_key 
+                    # We need to use the len of the exact match to avoid matching the wrong res_key
                     matched_length_by_res[res_key] = named_segments_count if named_segments_count != -1 else len(exact_match)
 
             # Find the longest match
@@ -321,17 +319,17 @@ class SyncPoint:
         res_data: List[ResourceSegment] = []
         for segment in target_segments:
             # Use the regex to create the res_data
-            if segment.get('regex') is not None:
-                    regex = segment.get('regex')
-                    matches = re.search(regex, input_matched_groups)
-                    multi_segments = matches.group()
-                    if multi_segments:
-                        for seg in multi_segments.split("/"):
-                            if seg: 
-                                res_data.append({
-                                    "resource_name": seg,
-                                    "resource_type": segment["type"]
-                                })
+            if segment.get("regex") is not None:
+                regex = segment.get("regex")
+                matches = re.search(regex, input_matched_groups)
+                multi_segments = matches.group()
+                if multi_segments:
+                    for seg in multi_segments.split("/"):
+                        if seg:
+                            res_data.append({
+                                "resource_name": seg,
+                                "resource_type": segment["type"]
+                            })
 
             else:
                 matched_groups = re.match(NAMED_TOKEN_REGEX, segment["name"])

--- a/cowbird/permissions_synchronizer.py
+++ b/cowbird/permissions_synchronizer.py
@@ -217,11 +217,15 @@ class SyncPoint:
         :param src_resource_tree: Resource tree associated with the permission to synchronize
         """
         resource_nametype_path = ""
-        for res_seg, res in zip(res_segments, src_resource_tree):
-            key = res_seg.get("field")
-            if key is None:
-                key = "resource_name"
+        res_segments_len = len(res_segments)
+        for index, res in enumerate(src_resource_tree):
             res_type = res["resource_type"]
+            if index < res_segments_len:
+                key = res_segments[index].get("field")
+                if key is None:
+                    key = "resource_name"
+            else:
+                key = "resource_name"
             resource_nametype_path += f"/{res[key]}{RES_NAMETYPE_SEPARATOR}{res_type}"
 
         return resource_nametype_path

--- a/cowbird/permissions_synchronizer.py
+++ b/cowbird/permissions_synchronizer.py
@@ -1,6 +1,6 @@
 import re
 from copy import deepcopy
-from typing import TYPE_CHECKING, Callable, Dict, Iterator, List, MutableMapping, Tuple, cast
+from typing import TYPE_CHECKING, Callable, Dict, Iterator, List, MutableMapping, Optional, Tuple, Union, cast
 
 from cowbird.config import (
     BIDIRECTIONAL_ARROW,
@@ -64,7 +64,7 @@ class Permission:
                  service_type: str,
                  resource_id: int,
                  resource_full_name: str,
-                 resource_display_name: str | None,
+                 resource_display_name: Optional[str],
                  name: str,
                  access: str,
                  scope: str,
@@ -237,7 +237,7 @@ class SyncPoint:
                 formatted_path += "/" + segment.split(RES_NAMETYPE_SEPARATOR)[0]
         return formatted_path
 
-    def _find_matching_res(self, permission: Permission, src_resource_tree: ResourceTree) -> Tuple[str, Dict[str, str] | str]:
+    def _find_matching_res(self, permission: Permission, src_resource_tree: ResourceTree) -> Tuple[str, Dict[str, str] or str]:
         """
         Finds a resource key that matches the input resource path, in the sync_permissions config. Note that it returns
         the longest match and only the named segments of the path are included in the length value. Any tokenized
@@ -352,7 +352,7 @@ class SyncPoint:
 
     def _get_resource_full_name_and_type(self,
                                          res_key: str,
-                                         matched_groups: Dict[str, str] | str,
+                                         matched_groups: Dict[str, str] or str,
                                          ) -> Tuple[str, List[ResourceSegment]]:
         """
         Finds the resource data from the config by using the resource key.
@@ -548,7 +548,7 @@ class SyncPoint:
 
     def _find_permissions_to_sync(self,
                                   src_res_key: str,
-                                  src_matched_groups: Dict[str, str] | str,
+                                  src_matched_groups: Dict[str, str] or str,
                                   input_permission: Permission,
                                   perm_operation: Callable[[List[PermissionConfigItemType]], None],
                                   ) -> PermissionData:

--- a/cowbird/permissions_synchronizer.py
+++ b/cowbird/permissions_synchronizer.py
@@ -1,6 +1,6 @@
 import re
 from copy import deepcopy
-from typing import TYPE_CHECKING, Callable, Collection, Dict, Iterator, List, MutableMapping, Tuple, cast
+from typing import TYPE_CHECKING, Callable, Collection, Dict, Iterator, List, MutableMapping, Tuple, Union, cast
 
 from cowbird.config import (
     BIDIRECTIONAL_ARROW,
@@ -242,7 +242,7 @@ class SyncPoint:
         return formatted_path
 
     def _find_matching_res(self, permission: Permission,
-                           src_resource_tree: ResourceTree) -> Tuple[str, Collection[str]]:
+                           src_resource_tree: ResourceTree) -> Tuple[str, Union[Collection[str], Dict[str, str]]]:
         """
         Finds a resource key that matches the input resource path, in the sync_permissions config. Note that it returns
         the longest match and only the named segments of the path are included in the length value. Any tokenized
@@ -273,13 +273,13 @@ class SyncPoint:
             # - /file
             #
             # In the case where a regex is used, the behavior is changed to search for the exact
-            # match in the res_segments. The lengh of the match is used to favor a more specific match.
+            # match in the resource_nametype_path. The lengh of the match is used to favor a more specific match.
             # Example:
             # 1:
-            # - //dir1/dir2//
-            # - //dir1/dir2//dir3// # We favor this path if it matches since it is more specific.
+            # - //res1/res2//
+            # - //res1/res2//res3// # We favor this path if it matches since it is more specific.
             # note: It is possible to have multiple resource in the same segment when using a custom
-            # regex that extract a display_name containing a path to a target resource.
+            # regex that extract a display_name containing a path to a specific resource.
 
             matched_length_by_res = {}
             matched_groups_by_res = {}
@@ -323,7 +323,7 @@ class SyncPoint:
 
     @staticmethod
     def _create_res_data(target_segments: List[ConfigSegment],
-                         input_matched_groups: Collection[str],
+                         input_matched_groups: Union[Collection[str], Dict[str, str]],
                          ) -> List[ResourceSegment]:
         """
         Creates resource data, by replacing any tokens found in the segment names to their actual corresponding values.
@@ -375,7 +375,7 @@ class SyncPoint:
 
     def _get_resource_full_name_and_type(self,
                                          res_key: str,
-                                         matched_groups: Collection[str],
+                                         matched_groups: Union[Collection[str], Dict[str, str]],
                                          ) -> Tuple[str, List[ResourceSegment]]:
         """
         Finds the resource data from the config by using the resource key.
@@ -435,7 +435,7 @@ class SyncPoint:
     def _filter_used_targets(self,
                              target_res_and_permissions: TargetResourcePermissions,
                              input_src_res_key: str,
-                             src_matched_groups: Collection[str],
+                             src_matched_groups: Union[Collection[str], Dict[str, str]],
                              input_permission: Permission,
                              ) -> Tuple[Dict[str, List[str]], Dict[str, List[str]]]:
         """
@@ -514,7 +514,7 @@ class SyncPoint:
     def _get_permission_data(self,
                              user_targets: Dict[str, List[str]],
                              group_targets: Dict[str, List[str]],
-                             src_matched_groups: Collection[str],
+                             src_matched_groups: Union[Collection[str], Dict[str, str]],
                              input_permission: Permission) -> PermissionData:
         """
         Formats permissions data to send to Magpie. Output contains, for each target resource key, the resource path
@@ -555,7 +555,7 @@ class SyncPoint:
                                        target_res_and_permissions: TargetResourcePermissions,
                                        input_permission: Permission,
                                        input_src_res_key: str,
-                                       src_matched_groups: Collection[str],
+                                       src_matched_groups: Union[Collection[str], Dict[str, str]],
                                        ) -> PermissionData:
         """
         Removes every source resource found in the mappings that has an existing permission that is synced to one of the
@@ -571,7 +571,7 @@ class SyncPoint:
 
     def _find_permissions_to_sync(self,
                                   src_res_key: str,
-                                  src_matched_groups: Collection[str],
+                                  src_matched_groups: Union[Collection[str], Dict[str, str]],
                                   input_permission: Permission,
                                   perm_operation: Callable[[List[PermissionConfigItemType]], None],
                                   ) -> PermissionData:

--- a/cowbird/permissions_synchronizer.py
+++ b/cowbird/permissions_synchronizer.py
@@ -208,7 +208,8 @@ class SyncPoint:
         return res_regex, named_segments_count
 
     @staticmethod
-    def _generate_nametype_path_from_segments(res_segments: List[ConfigSegment], src_resource_tree: ResourceTree) -> str:
+    def _generate_nametype_path_from_segments(res_segments: List[ConfigSegment],
+                                              src_resource_tree: ResourceTree) -> str:
         """
         Generate nametype path (ex.: /name1::type1/name2::type2 where name can be a field found in ResourceSegment).
 
@@ -220,7 +221,8 @@ class SyncPoint:
             key = res_seg.get("field")
             if key is None:
                 key = "resource_name"
-            resource_nametype_path += f'/{res[key]}{RES_NAMETYPE_SEPARATOR}{res["resource_type"]}'
+            res_type = res["resource_type"]
+            resource_nametype_path += f"/{res[key]}{RES_NAMETYPE_SEPARATOR}{res_type}"
 
         return resource_nametype_path
 
@@ -235,7 +237,8 @@ class SyncPoint:
                 formatted_path += "/" + segment.split(RES_NAMETYPE_SEPARATOR)[0]
         return formatted_path
 
-    def _find_matching_res(self, permission: Permission, src_resource_tree: ResourceTree) -> Tuple[str, Collection[str]]:
+    def _find_matching_res(self, permission: Permission,
+                           src_resource_tree: ResourceTree) -> Tuple[str, Collection[str]]:
         """
         Finds a resource key that matches the input resource path, in the sync_permissions config. Note that it returns
         the longest match and only the named segments of the path are included in the length value. Any tokenized
@@ -265,21 +268,22 @@ class SyncPoint:
             # - /**/file
             # - /file
             #
-            # In the case where a regex is used, the behavior is changed to search for the exact match in the res_segments.
-            # The lengh of the match is used to favor a more specific match.
+            # In the case where a regex is used, the behavior is changed to search for the exact
+            # match in the res_segments. The lengh of the match is used to favor a more specific match.
             # Example:
             # 1:
             # - //dir1/dir2//
             # - //dir1/dir2//dir3// # We favor this path if it matches since it is more specific.
-            # note: It is possible to have multiple dir in the same segment when using a custom regex that extract a display_name
-            # containing a path to a target resource.
+            # note: It is possible to have multiple resource in the same segment when using a custom
+            # regex that extract a display_name containing a path to a target resource.
 
             matched_length_by_res = {}
             matched_groups_by_res = {}
             service_resources = self.services[service_type]
             for res_key, res_segments in service_resources.items():
                 res_regex, named_segments_count = SyncPoint._generate_regex_from_segments(res_segments)
-                resource_nametype_path = SyncPoint._generate_nametype_path_from_segments(res_segments, src_resource_tree)
+                resource_nametype_path = SyncPoint._generate_nametype_path_from_segments(res_segments,
+                                                                                         src_resource_tree)
                 if named_segments_count == -1:
                     # To be able to match a path anywhere in the resource_nametype_path we need to use search
                     # only when the field regex is passed in the res_segments. This allow to stay backward compatible.
@@ -294,9 +298,11 @@ class SyncPoint:
                             matched_groups["multi_token"]
                         )
                     matched_groups_by_res[res_key] = matched_groups
-                    # Since we want to be able to match multiple dir /dir1/dir2/dir3/** in the same segment if a custom regex is passed.
-                    # We need to use the len of the exact match to avoid matching the wrong res_key
-                    matched_length_by_res[res_key] = named_segments_count if named_segments_count != -1 else len(exact_match)
+                    # Since we want to be able to match multiple dir /dir1/dir2/dir3/** in the same segment
+                    # if a custom regex is passed. We need to use the len of the exact match to avoid matching
+                    # the wrong res_key
+                    matched_length_by_res[res_key] = (named_segments_count if named_segments_count != -1
+                                                      else len(exact_match))
 
             # Find the longest match
             max_match_len = max(matched_length_by_res.values(), default=0)

--- a/cowbird/permissions_synchronizer.py
+++ b/cowbird/permissions_synchronizer.py
@@ -64,6 +64,7 @@ class Permission:
                  service_type: str,
                  resource_id: int,
                  resource_full_name: str,
+                 resource_display_name: str | None,
                  name: str,
                  access: str,
                  scope: str,
@@ -74,6 +75,7 @@ class Permission:
         self.service_type = service_type
         self.resource_id = resource_id
         self.resource_full_name = resource_full_name
+        self.resource_display_name = resource_display_name
         self.name = name
         self.access = access
         self.scope = scope
@@ -85,6 +87,7 @@ class Permission:
                 self.service_type == other.service_type and
                 self.resource_id == other.resource_id and
                 self.resource_full_name == other.resource_full_name and
+                self.resource_display_name == other.resource_display_name and
                 self.name == other.name and
                 self.access == other.access and
                 self.scope == other.scope and
@@ -184,10 +187,17 @@ class SyncPoint:
         for segment in res_segments:
             matched_groups = re.match(NAMED_TOKEN_REGEX, segment["name"])
             if matched_groups:
-                # match any name with specific type 1 time only
-                res_regex += (
-                    rf"/(?P<{matched_groups.groups()[0]}>{SEGMENT_NAME_REGEX})"
-                    rf"{RES_NAMETYPE_SEPARATOR}{segment['type']}"
+                if segment.get('regex') is not None:
+                    # if a regex is passed, override the current regex
+                    regex = segment.get('regex')
+                    res_regex = (
+                            rf"{regex}"
+                        )
+                else:
+                    # match any name with specific type 1 time only
+                    res_regex += (
+                        rf"/(?P<{matched_groups.groups()[0]}>{SEGMENT_NAME_REGEX})"
+                        rf"{RES_NAMETYPE_SEPARATOR}{segment['type']}"
                 )
             elif segment["name"] == MULTI_TOKEN:
                 # match any name with specific type, 0 or more times
@@ -196,8 +206,25 @@ class SyncPoint:
                 # match name and type exactly
                 res_regex += rf"/{segment['name']}{RES_NAMETYPE_SEPARATOR}{segment['type']}"
                 named_segments_count += 1
-        res_regex += r"$"
         return res_regex, named_segments_count
+
+    @staticmethod
+    def _generate_nametype_path_from_segments(res_segments: List[ConfigSegment], src_resource_tree: ResourceTree ) -> str:
+        """
+        Generate nametype path (ex.: /name1::type1/name2::type2 where name can be a key from src_resource_tree ).
+        """
+        resource_nametype_path = ""
+        index = 0
+        for res in src_resource_tree:
+            if(index < len(res_segments)):
+                key = res_segments[index].get('field') if res_segments[index].get('field') is not None else "resource_name"
+            else:
+                key = 'resource_name'
+            resource_nametype_path += f"/{res[key]}{RES_NAMETYPE_SEPARATOR}{res['resource_type']}"
+            index = index + 1
+
+        return resource_nametype_path
+
 
     @staticmethod
     def _remove_type_from_nametype_path(nametype_path: str) -> str:
@@ -210,16 +237,18 @@ class SyncPoint:
                 formatted_path += "/" + segment.split(RES_NAMETYPE_SEPARATOR)[0]
         return formatted_path
 
-    def _find_matching_res(self, service_type: str, resource_nametype_path: str) -> Tuple[str, Dict[str, str]]:
+    def _find_matching_res(self, permission: Permission, src_resource_tree: ResourceTree) -> Tuple[str, Dict[str, str] | str]:
         """
         Finds a resource key that matches the input resource path, in the sync_permissions config. Note that it returns
         the longest match and only the named segments of the path are included in the length value. Any tokenized
         segment is ignored in the length.
 
-        :param service_type: Type of the service associated with the input resource.
+        :param permission: Permission of the service associated with the input resource.
         :param resource_nametype_path: Full resource path name, which includes the type of each segment
                                        (ex.: /name1::type1/name2::type2)
         """
+        
+        service_type = permission.service_type
         if service_type in self.services:
             # Find which resource from the config matches with the input permission's resource tree
             # The length of a match is determined by the number of named segments matching the input resource.
@@ -244,15 +273,19 @@ class SyncPoint:
             service_resources = self.services[service_type]
             for res_key, res_segments in service_resources.items():
                 res_regex, named_segments_count = SyncPoint._generate_regex_from_segments(res_segments)
-                matches = re.match(res_regex, resource_nametype_path)
+                resource_nametype_path = SyncPoint._generate_nametype_path_from_segments(res_segments, src_resource_tree)
+                # to be able to match anywhere in the string use search instead of match
+                matches = re.search(res_regex, resource_nametype_path)
                 if matches:
-                    matched_groups = matches.groupdict()
+                    # if we have an exact match use the string directly
+                    exact_match = matches.group()
+                    matched_groups = matches.groupdict() if exact_match is None else exact_match
                     if "multi_token" in matched_groups:
                         matched_groups["multi_token"] = SyncPoint._remove_type_from_nametype_path(
                             matched_groups["multi_token"]
                         )
                     matched_groups_by_res[res_key] = matched_groups
-                    matched_length_by_res[res_key] = named_segments_count
+                    matched_length_by_res[res_key] = named_segments_count if exact_match is None else len(exact_match)
 
             # Find the longest match
             max_match_len = max(matched_length_by_res.values(), default=0)
@@ -280,32 +313,46 @@ class SyncPoint:
         """
         res_data: List[ResourceSegment] = []
         for segment in target_segments:
-            matched_groups = re.match(NAMED_TOKEN_REGEX, segment["name"])
-            if matched_groups:
-                res_data.append({
-                    "resource_name": input_matched_groups[matched_groups.groups()[0]],
-                    "resource_type": segment["type"]
-                })
-            elif segment["name"] == MULTI_TOKEN:
-                multi_segments = input_matched_groups["multi_token"]
-                # Skip the segment if the multi_token matched 0 times, resulting in an empty string.
-                if multi_segments:
-                    for seg in multi_segments.split("/"):
-                        if seg:  # Ignore empty splits
-                            res_data.append({
-                                "resource_name": seg,
-                                "resource_type": segment["type"]
-                            })
+            # Use the regex to create the res_data
+            if segment.get('regex') is not None:
+                    regex = segment.get('regex')
+                    matches = re.search(regex, input_matched_groups)
+                    multi_segments = matches.group()
+                    if multi_segments:
+                        for seg in multi_segments.split("/"):
+                            if seg: 
+                                res_data.append({
+                                    "resource_name": seg,
+                                    "resource_type": segment["type"]
+                                })
+
             else:
-                res_data.append({
-                    "resource_name": segment["name"],
-                    "resource_type": segment["type"]
-                })
+                matched_groups = re.match(NAMED_TOKEN_REGEX, segment["name"])
+                if matched_groups:
+                    res_data.append({
+                        "resource_name": input_matched_groups[matched_groups.groups()[0]],
+                        "resource_type": segment["type"]
+                    })
+                elif segment["name"] == MULTI_TOKEN:
+                    multi_segments = input_matched_groups["multi_token"]
+                    # Skip the segment if the multi_token matched 0 times, resulting in an empty string.
+                    if multi_segments:
+                        for seg in multi_segments.split("/"):
+                            if seg:  # Ignore empty splits
+                                res_data.append({
+                                    "resource_name": seg,
+                                    "resource_type": segment["type"]
+                                })
+                else:
+                    res_data.append({
+                        "resource_name": segment["name"],
+                        "resource_type": segment["type"]
+                    })
         return res_data
 
     def _get_resource_full_name_and_type(self,
                                          res_key: str,
-                                         matched_groups: Dict[str, str],
+                                         matched_groups: Dict[str, str] | str,
                                          ) -> Tuple[str, List[ResourceSegment]]:
         """
         Finds the resource data from the config by using the resource key.
@@ -501,7 +548,7 @@ class SyncPoint:
 
     def _find_permissions_to_sync(self,
                                   src_res_key: str,
-                                  src_matched_groups: Dict[str, str],
+                                  src_matched_groups: Dict[str, str] | str,
                                   input_permission: Permission,
                                   perm_operation: Callable[[List[PermissionConfigItemType]], None],
                                   ) -> PermissionData:
@@ -543,11 +590,7 @@ class SyncPoint:
         :param permission: Permission to synchronize with others services
         :param src_resource_tree: Resource tree associated with the permission to synchronize
         """
-        resource_nametype_path = ""
-        for res in src_resource_tree:
-            resource_nametype_path += f"/{res['resource_name']}{RES_NAMETYPE_SEPARATOR}{res['resource_type']}"
-
-        src_res_key, src_matched_groups = self._find_matching_res(permission.service_type, resource_nametype_path)
+        src_res_key, src_matched_groups = self._find_matching_res(permission, src_resource_tree)
         if not src_res_key:
             # A matching resource was not found in the sync config, nothing to do.
             return

--- a/cowbird/typedefs.py
+++ b/cowbird/typedefs.py
@@ -119,7 +119,7 @@ ConfigItem = Dict[str, JSON]
 ConfigList = List[ConfigItem]
 ConfigDict = Dict[str, Union[str, ConfigItem, ConfigList, JSON]]
 ConfigResTokenInfo = TypedDict("ConfigResTokenInfo", {"has_multi_token": bool, "named_tokens": MutableSet[str]})
-ConfigSegment = TypedDict("ConfigSegment", {"name": str, "type": str})
+ConfigSegment = TypedDict("ConfigSegment", {"name": str, "type": str, "field": str | None, "regex": str | None})
 
 SyncPointMappingType = List[str]
 SyncPointServicesType = Dict[
@@ -142,7 +142,7 @@ SyncPointConfig = Dict[
     SyncPermissionConfig,
 ]
 
-ResourceSegment = TypedDict("ResourceSegment", {"resource_name": str, "resource_type": str})
+ResourceSegment = TypedDict("ResourceSegment", {"resource_name": str, "resource_type": str, "resource_display_name": str | None})
 ResourceTree = List[
     Dict[
         str,

--- a/cowbird/typedefs.py
+++ b/cowbird/typedefs.py
@@ -119,7 +119,7 @@ ConfigItem = Dict[str, JSON]
 ConfigList = List[ConfigItem]
 ConfigDict = Dict[str, Union[str, ConfigItem, ConfigList, JSON]]
 ConfigResTokenInfo = TypedDict("ConfigResTokenInfo", {"has_multi_token": bool, "named_tokens": MutableSet[str]})
-ConfigSegment = TypedDict("ConfigSegment", {"name": str, "type": str, "field": str | None, "regex": str | None})
+ConfigSegment = TypedDict("ConfigSegment", {"name": str, "type": str, "field": Optional[str], "regex": Optional[str]})
 
 SyncPointMappingType = List[str]
 SyncPointServicesType = Dict[
@@ -142,7 +142,7 @@ SyncPointConfig = Dict[
     SyncPermissionConfig,
 ]
 
-ResourceSegment = TypedDict("ResourceSegment", {"resource_name": str, "resource_type": str, "resource_display_name": str | None})
+ResourceSegment = TypedDict("ResourceSegment", {"resource_name": str, "resource_type": str, "resource_display_name": Optional[str]})
 ResourceTree = List[
     Dict[
         str,

--- a/cowbird/typedefs.py
+++ b/cowbird/typedefs.py
@@ -142,7 +142,7 @@ SyncPointConfig = Dict[
     SyncPermissionConfig,
 ]
 
-ResourceSegment = TypedDict("ResourceSegment", {"resource_name": str, "resource_type": str, "resource_display_name": Optional[str]})
+ResourceSegment = TypedDict("ResourceSegment", {"resource_name": str, "resource_type": str, "resource_display_name": NotRequired[str]})
 ResourceTree = List[
     Dict[
         str,

--- a/cowbird/typedefs.py
+++ b/cowbird/typedefs.py
@@ -147,7 +147,7 @@ ResourceTree = List[
     Dict[
         str,
         # FIXME: replace by a more specific type provided by Magpie directly if eventually implemented
-        #   Only partial fields are provided below (resource_name/resource_type),
+        #   Only partial fields are provided below (resource_name/resource_type/resource_display_name),
         #   because those are the only ones used for now in Cowbird's sync operation.
         #   This actually contains more details such as the resource ID, permission names, etc.
         #   (see the response body of 'GET /magpie/resources/{resource_id}' for exact content).

--- a/cowbird/typedefs.py
+++ b/cowbird/typedefs.py
@@ -142,7 +142,8 @@ SyncPointConfig = Dict[
     SyncPermissionConfig,
 ]
 
-ResourceSegment = TypedDict("ResourceSegment", {"resource_name": str, "resource_type": str, "resource_display_name": NotRequired[str]})
+ResourceSegment = TypedDict("ResourceSegment", {"resource_name": str, "resource_type": str,
+                                                "resource_display_name": NotRequired[str]})
 ResourceTree = List[
     Dict[
         str,

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -139,13 +139,13 @@ multiple choices of matching are possible.
 We could match ``seg1/seg2`` with the first token, and ``seg3`` with the second token,
 we could also match ``seg1`` with the first token, and ``seg2/seg3`` with the second token, etc.
 
-The :key:`field` : This is useful when we want to have a different mapping between resources. The resource_name
+The key ``field`` is useful when we want to have a different mapping between resources. The ``resource_name``
 is used by default, but another key from the `Magpie`_ resource schema can be used, if specified by using the
-:key:`field`.
+key ``field``.
 
-A regular expression :key:`regex` may be used to extract the desired information from the ``nametype_path``.
+A regular expression ``regex`` may be used to extract the desired information from the ``nametype_path``.
 This will override the default behaviour of matching each segment with another segment and will instead use
-what is extracted from the segment and prioritize the longest match. When used in the target, the :key:`regex`
+what is extracted from the segment and prioritize the longest match. When used in the target, the ``regex``
 extracts each resource in the segment with the same type.
 
 The variables, tokens and regex are useful to know the type of any segments that doesn't have a fixed name.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -139,7 +139,14 @@ multiple choices of matching are possible.
 We could match ``seg1/seg2`` with the first token, and ``seg3`` with the second token,
 we could also match ``seg1`` with the first token, and ``seg2/seg3`` with the second token, etc.
 
-The variables and tokens are useful to know the type of any segments that doesn't have a fixed name.
+In addition of using the name of the segment it is possible to use instead a key found in `Magpie`_ resource schema
+with the :key:`field`. This is useful when we want to be able to have a different mapping between resources.
+A regular expression :key:`regex` may be used to extract the desired information from the ``nametype_path``.
+This will override the default behaviour of matching each segment with other segment and will instead use
+what is extracted from the segment and prioritize the longest match. When used in the target, the :key:`regex`
+extracts each resource in the segment with the same type.
+
+The variables, tokens and regex are useful to know the type of any segments that doesn't have a fixed name.
 
 .. _permissions_mapping:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -139,10 +139,12 @@ multiple choices of matching are possible.
 We could match ``seg1/seg2`` with the first token, and ``seg3`` with the second token,
 we could also match ``seg1`` with the first token, and ``seg2/seg3`` with the second token, etc.
 
-In addition of using the name of the segment it is possible to use instead a key found in `Magpie`_ resource schema
-with the :key:`field`. This is useful when we want to be able to have a different mapping between resources.
+The :key:`field` : This is useful when we want to have a different mapping between resources. The resource_name
+is used by default, but another key from the `Magpie`_ resource schema can be used, if specified by using the
+:key:`field`.
+
 A regular expression :key:`regex` may be used to extract the desired information from the ``nametype_path``.
-This will override the default behaviour of matching each segment with other segment and will instead use
+This will override the default behaviour of matching each segment with another segment and will instead use
 what is extracted from the segment and prioritize the longest match. When used in the target, the :key:`regex`
 extracts each resource in the segment with the same type.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ exclude =
 	eggs,
 	parts,
 	share,
+	node_modules,
 
 [pylint]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ exclude =
 [pylint]
 
 [bandit]
-exclude = *.egg-info,build,dist,env,./tests,test_*
+exclude = *.egg-info,build,dist,env,./tests,test_*,./node_modules
 targets = .
 
 [tool:isort]


### PR DESCRIPTION
* Add optional key ``field`` and ``regex`` to be used in the ``sync_permissions`` section found in the config.
  This allows to sync permissions using a field other than ``resource_full_name`` when creating the ``name:type``
  from the segment ``ex.: /field1::type1/field2::type2``. Adds support to use ``resource_display_name``.
* The ``regex`` is used to extract the desired information from the ``nametype_path``. It should be used to do an
  exact match. This new search overrides the default way of matching each segment with the ``nametype_path``. 
  In the case where a ``regex`` is found in the target segment, the data will be formed using the same ``resource_type``
  for every match in the same segment. Similary, as using ``- name: "**"`` in the config to match multiple segment,
  it is possible to use a ``regex`` to match multiple resources in the same segment with ``regex: '(?<=:).*\/?(?=\/)'``