### PR TITLE
Do not treat handlers actions that have not been implemented as a dispatch failure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Changes
 * Pin ``watchdog>=5`` to employ typing fixes.
 * Pin ``requests>=2.32.3`` to fix security vulnerability.
 * Pin ``setuptools>=70.0.0`` to fix security vulnerability.
+* Do not treat handlers actions that have not been implemented as a dispatch failure.
 
 `2.4.0 <https://github.com/Ouranosinc/cowbird/tree/2.4.0>`_ (2024-07-09)
 ------------------------------------------------------------------------------------

--- a/cowbird/api/webhooks/views.py
+++ b/cowbird/api/webhooks/views.py
@@ -33,8 +33,6 @@ def dispatch(handler_fct: Callable[[Handler], None]) -> None:
         try:
             LOGGER.info("Dispatching event [%s] for handler [%s].", event_name, handler.name)
             handler_fct(handler)
-        except NotImplementedError:
-            LOGGER.debug("Event [%s] for handler [%s] is not implemented.", event_name, handler.name)
         except Exception as exception:  # noqa
             exceptions.append(exception)
             LOGGER.error("Exception raised while handling event [%s] for handler [%s] : [%r].",

--- a/cowbird/api/webhooks/views.py
+++ b/cowbird/api/webhooks/views.py
@@ -33,6 +33,8 @@ def dispatch(handler_fct: Callable[[Handler], None]) -> None:
         try:
             LOGGER.info("Dispatching event [%s] for handler [%s].", event_name, handler.name)
             handler_fct(handler)
+        except NotImplementedError:
+            LOGGER.debug("Event [%s] for handler [%s] is not implemented.", event_name, handler.name)
         except Exception as exception:  # noqa
             exceptions.append(exception)
             LOGGER.error("Exception raised while handling event [%s] for handler [%s] : [%r].",

--- a/cowbird/handlers/impl/catalog.py
+++ b/cowbird/handlers/impl/catalog.py
@@ -35,10 +35,10 @@ class Catalog(Handler, FSMonitor):
         Monitoring().unregister(self._user_workspace_dir(user_name), self)
 
     def permission_created(self, permission: Permission) -> None:
-        LOGGER.debug("Event [permission_created] for handler [%s] is not implemented", self.name)
+        LOGGER.info("Event [permission_created] for handler [%s] is not implemented", self.name)
 
     def permission_deleted(self, permission: Permission) -> None:
-        LOGGER.debug("Event [permission_deleted] for handler [%s] is not implemented", self.name)
+        LOGGER.info("Event [permission_deleted] for handler [%s] is not implemented", self.name)
 
     @staticmethod
     def get_instance() -> Optional["Catalog"]:
@@ -74,4 +74,4 @@ class Catalog(Handler, FSMonitor):
 
     def resync(self) -> None:
         # FIXME: this should be implemented in the eventual task addressing the resync mechanism.
-        LOGGER.debug("Event [resync] for handler [%s] is not implemented", self.name)
+        LOGGER.warning("Event [resync] for handler [%s] is not implemented but should be in the future", self.name)

--- a/cowbird/handlers/impl/catalog.py
+++ b/cowbird/handlers/impl/catalog.py
@@ -35,10 +35,10 @@ class Catalog(Handler, FSMonitor):
         Monitoring().unregister(self._user_workspace_dir(user_name), self)
 
     def permission_created(self, permission: Permission) -> None:
-        raise NotImplementedError
+        LOGGER.debug("Event [permission_created] for handler [%s] is not implemented", self.name)
 
     def permission_deleted(self, permission: Permission) -> None:
-        raise NotImplementedError
+        LOGGER.debug("Event [permission_deleted] for handler [%s] is not implemented", self.name)
 
     @staticmethod
     def get_instance() -> Optional["Catalog"]:
@@ -74,4 +74,4 @@ class Catalog(Handler, FSMonitor):
 
     def resync(self) -> None:
         # FIXME: this should be implemented in the eventual task addressing the resync mechanism.
-        raise NotImplementedError
+        LOGGER.debug("Event [resync] for handler [%s] is not implemented", self.name)

--- a/cowbird/handlers/impl/geoserver.py
+++ b/cowbird/handlers/impl/geoserver.py
@@ -388,7 +388,7 @@ class Geoserver(Handler, FSMonitor):
 
     def resync(self) -> None:
         # FIXME: this should be implemented in the eventual task addressing the resync mechanism.
-        raise NotImplementedError
+        LOGGER.debug("Event [resync] for handler [%s] is not implemented", self.name)
 
     @staticmethod
     def _is_permission_update_required(effective_permissions: List[JSON],

--- a/cowbird/handlers/impl/geoserver.py
+++ b/cowbird/handlers/impl/geoserver.py
@@ -388,7 +388,7 @@ class Geoserver(Handler, FSMonitor):
 
     def resync(self) -> None:
         # FIXME: this should be implemented in the eventual task addressing the resync mechanism.
-        LOGGER.debug("Event [resync] for handler [%s] is not implemented", self.name)
+        LOGGER.warning("Event [resync] for handler [%s] is not implemented but should be in the future", self.name)
 
     @staticmethod
     def _is_permission_update_required(effective_permissions: List[JSON],

--- a/cowbird/handlers/impl/magpie.py
+++ b/cowbird/handlers/impl/magpie.py
@@ -290,10 +290,12 @@ class Magpie(Handler):
         return resp.json()
 
     def user_created(self, user_name: str) -> None:
-        LOGGER.info("Event [user_created] for handler [%s] is not implemented", self.name)
+        LOGGER.warning("Event [user_created] for handler [%s] is not implemented since Magpie "
+                       "has already created the user.", self.name)
 
     def user_deleted(self, user_name: str) -> None:
-        LOGGER.info("Event [user_deleted] for handler [%s] is not implemented", self.name)
+        LOGGER.warning("Event [user_deleted] for handler [%s] is not implemented since Magpie "
+                       "has already deleted the user.", self.name)
 
     def permission_created(self, permission: Permission) -> None:
         self.permissions_synch.create_permission(permission)

--- a/cowbird/handlers/impl/magpie.py
+++ b/cowbird/handlers/impl/magpie.py
@@ -290,10 +290,10 @@ class Magpie(Handler):
         return resp.json()
 
     def user_created(self, user_name: str) -> None:
-        raise NotImplementedError
+        LOGGER.debug("Event [user_created] for handler [%s] is not implemented", self.name)
 
     def user_deleted(self, user_name: str) -> None:
-        raise NotImplementedError
+        LOGGER.debug("Event [user_deleted] for handler [%s] is not implemented", self.name)
 
     def permission_created(self, permission: Permission) -> None:
         self.permissions_synch.create_permission(permission)
@@ -303,7 +303,7 @@ class Magpie(Handler):
 
     def resync(self) -> None:
         # FIXME: this should be implemented in the eventual task addressing the resync mechanism.
-        raise NotImplementedError
+        LOGGER.debug("Event [resync] for handler [%s] is not implemented", self.name)
 
     def create_permissions(self, permissions_data: List[PermissionConfigItemType]) -> None:
         """

--- a/cowbird/handlers/impl/magpie.py
+++ b/cowbird/handlers/impl/magpie.py
@@ -290,10 +290,10 @@ class Magpie(Handler):
         return resp.json()
 
     def user_created(self, user_name: str) -> None:
-        LOGGER.debug("Event [user_created] for handler [%s] is not implemented", self.name)
+        LOGGER.info("Event [user_created] for handler [%s] is not implemented", self.name)
 
     def user_deleted(self, user_name: str) -> None:
-        LOGGER.debug("Event [user_deleted] for handler [%s] is not implemented", self.name)
+        LOGGER.info("Event [user_deleted] for handler [%s] is not implemented", self.name)
 
     def permission_created(self, permission: Permission) -> None:
         self.permissions_synch.create_permission(permission)
@@ -303,7 +303,7 @@ class Magpie(Handler):
 
     def resync(self) -> None:
         # FIXME: this should be implemented in the eventual task addressing the resync mechanism.
-        LOGGER.debug("Event [resync] for handler [%s] is not implemented", self.name)
+        LOGGER.warning("Event [resync] for handler [%s] is not implemented but should be in the future", self.name)
 
     def create_permissions(self, permissions_data: List[PermissionConfigItemType]) -> None:
         """

--- a/cowbird/handlers/impl/nginx.py
+++ b/cowbird/handlers/impl/nginx.py
@@ -25,17 +25,17 @@ class Nginx(Handler):
         super(Nginx, self).__init__(settings, name, **kwargs)
 
     def user_created(self, user_name: str) -> None:
-        LOGGER.debug("Event [user_created] for handler [%s] is not implemented", self.name)
+        LOGGER.info("Event [user_created] for handler [%s] is not implemented", self.name)
 
     def user_deleted(self, user_name: str) -> None:
-        LOGGER.debug("Event [user_deleted] for handler [%s] is not implemented", self.name)
+        LOGGER.info("Event [user_deleted] for handler [%s] is not implemented", self.name)
 
     def permission_created(self, permission: Permission) -> None:
-        LOGGER.debug("Event [permission_created] for handler [%s] is not implemented", self.name)
+        LOGGER.info("Event [permission_created] for handler [%s] is not implemented", self.name)
 
     def permission_deleted(self, permission: Permission) -> None:
-        LOGGER.debug("Event [permission_deleted] for handler [%s] is not implemented", self.name)
+        LOGGER.info("Event [permission_deleted] for handler [%s] is not implemented", self.name)
 
     def resync(self) -> None:
         # FIXME: this should be implemented in the eventual task addressing the resync mechanism.:
-        LOGGER.debug("Event [resync] for handler [%s] is not implemented", self.name)
+        LOGGER.warning("Event [resync] for handler [%s] is not implemented but should be in the future", self.name)

--- a/cowbird/handlers/impl/nginx.py
+++ b/cowbird/handlers/impl/nginx.py
@@ -5,7 +5,6 @@ from cowbird.permissions_synchronizer import Permission
 from cowbird.typedefs import SettingsType
 from cowbird.utils import get_logger
 
-
 LOGGER = get_logger(__name__)
 
 

--- a/cowbird/handlers/impl/nginx.py
+++ b/cowbird/handlers/impl/nginx.py
@@ -3,6 +3,10 @@ from typing import Any
 from cowbird.handlers.handler import Handler
 from cowbird.permissions_synchronizer import Permission
 from cowbird.typedefs import SettingsType
+from cowbird.utils import get_logger
+
+
+LOGGER = get_logger(__name__)
 
 
 class Nginx(Handler):
@@ -21,17 +25,17 @@ class Nginx(Handler):
         super(Nginx, self).__init__(settings, name, **kwargs)
 
     def user_created(self, user_name: str) -> None:
-        raise NotImplementedError
+        LOGGER.debug("Event [user_created] for handler [%s] is not implemented", self.name)
 
     def user_deleted(self, user_name: str) -> None:
-        raise NotImplementedError
+        LOGGER.debug("Event [user_deleted] for handler [%s] is not implemented", self.name)
 
     def permission_created(self, permission: Permission) -> None:
-        raise NotImplementedError
+        LOGGER.debug("Event [permission_created] for handler [%s] is not implemented", self.name)
 
     def permission_deleted(self, permission: Permission) -> None:
-        raise NotImplementedError
+        LOGGER.debug("Event [permission_deleted] for handler [%s] is not implemented", self.name)
 
     def resync(self) -> None:
         # FIXME: this should be implemented in the eventual task addressing the resync mechanism.:
-        raise NotImplementedError
+        LOGGER.debug("Event [resync] for handler [%s] is not implemented", self.name)

--- a/cowbird/handlers/impl/thredds.py
+++ b/cowbird/handlers/impl/thredds.py
@@ -25,17 +25,17 @@ class Thredds(Handler):
         super(Thredds, self).__init__(settings, name, **kwargs)
 
     def user_created(self, user_name: str) -> None:
-        LOGGER.debug("Event [user_created] for handler [%s] is not implemented", self.name)
+        LOGGER.info("Event [user_created] for handler [%s] is not implemented", self.name)
 
     def user_deleted(self, user_name: str) -> None:
-        LOGGER.debug("Event [user_deleted] for handler [%s] is not implemented", self.name)
+        LOGGER.info("Event [user_deleted] for handler [%s] is not implemented", self.name)
 
     def permission_created(self, permission: Permission) -> None:
-        LOGGER.debug("Event [permission_created] for handler [%s] is not implemented", self.name)
+        LOGGER.info("Event [permission_created] for handler [%s] is not implemented", self.name)
 
     def permission_deleted(self, permission: Permission) -> None:
-        LOGGER.debug("Event [permission_deleted] for handler [%s] is not implemented", self.name)
+        LOGGER.info("Event [permission_deleted] for handler [%s] is not implemented", self.name)
 
     def resync(self) -> None:
         # FIXME: this should be implemented in the eventual task addressing the resync mechanism.
-        LOGGER.debug("Event [resync] for handler [%s] is not implemented", self.name)
+        LOGGER.warning("Event [resync] for handler [%s] is not implemented but should be in the future", self.name)

--- a/cowbird/handlers/impl/thredds.py
+++ b/cowbird/handlers/impl/thredds.py
@@ -3,6 +3,10 @@ from typing import Any
 from cowbird.handlers.handler import Handler
 from cowbird.permissions_synchronizer import Permission
 from cowbird.typedefs import SettingsType
+from cowbird.utils import get_logger
+
+
+LOGGER = get_logger(__name__)
 
 
 class Thredds(Handler):
@@ -21,17 +25,17 @@ class Thredds(Handler):
         super(Thredds, self).__init__(settings, name, **kwargs)
 
     def user_created(self, user_name: str) -> None:
-        raise NotImplementedError
+        LOGGER.debug("Event [user_created] for handler [%s] is not implemented", self.name)
 
     def user_deleted(self, user_name: str) -> None:
-        raise NotImplementedError
+        LOGGER.debug("Event [user_deleted] for handler [%s] is not implemented", self.name)
 
     def permission_created(self, permission: Permission) -> None:
-        raise NotImplementedError
+        LOGGER.debug("Event [permission_created] for handler [%s] is not implemented", self.name)
 
     def permission_deleted(self, permission: Permission) -> None:
-        raise NotImplementedError
+        LOGGER.debug("Event [permission_deleted] for handler [%s] is not implemented", self.name)
 
     def resync(self) -> None:
         # FIXME: this should be implemented in the eventual task addressing the resync mechanism.
-        raise NotImplementedError
+        LOGGER.debug("Event [resync] for handler [%s] is not implemented", self.name)

--- a/cowbird/handlers/impl/thredds.py
+++ b/cowbird/handlers/impl/thredds.py
@@ -5,7 +5,6 @@ from cowbird.permissions_synchronizer import Permission
 from cowbird.typedefs import SettingsType
 from cowbird.utils import get_logger
 
-
 LOGGER = get_logger(__name__)
 
 


### PR DESCRIPTION
If a handler raises a `NotImplementedError` for a given action, Magpie will consider that a webhook failure. 

This is misleading because the webhook didn't actually fail, there was simply nothing to do since the action isn't implemented.

This PR changes the webhook dispatcher to treat handler actions that raise `NotImplementedError`s as a noop instead of as an error.

For example:

- when a user is created, the `Nginx.user_created` handler is triggered, this method raises a `NotImplementedError`  which is reported to Magpie as a webhook failure.
- Admins who are then looking at the user status think that there is a cowbird error and that the user was not properly created. In fact, the user was properly created since all webhooks that **are implemented** ran with no errors.

Other possible solutions to this problem:

- instead of raising a `NotImplementedError`, concrete implementations of the `Handler` class can simply `pass` instead
- instead of raising a `NotImplementedError`, abstract methods in the `Handler` class can simply `pass` instead (all concrete implementations can then optionally override these methods if needed)