### PR TITLE
security update openssl dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,11 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/cowbird/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing yet.
+* Security update of Docker Alpine packages to
+  address `CVE-2026-31789 <https://nvd.nist.gov/vuln/detail/CVE-2026-31789>`_
+  (OpenSSL ``libcrypto3`` and ``libssl3`` upgraded to ``3.5.6-r0``) by adding ``apk upgrade`` to the Dockerfile.
+  Because the update is applied in general on Alpine packages rather than just the OpenSSL ones, it also includes
+  any other relevant security fixes that could have been published.
 
 `2.7.0 <https://github.com/Ouranosinc/cowbird/tree/2.7.0>`_ (2026-04-23)
 ------------------------------------------------------------------------------------

--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -13,6 +13,7 @@ WORKDIR ${COWBIRD_DIR}
 COPY cowbird/__init__.py cowbird/__meta__.py ${COWBIRD_DIR}/cowbird/
 COPY requirements* setup.py README.rst CHANGES.rst ${COWBIRD_DIR}/
 RUN apk update \
+    && apk upgrade --no-cache \
     && apk add \
     bash \
     grep \


### PR DESCRIPTION
- security fix OpenSSL https://nvd.nist.gov/vuln/detail/CVE-2026-31789
- potentially other fixes by updating all available Alpine packages